### PR TITLE
Skip failing test stub (as for now...)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,12 +4,13 @@ import { Provider } from 'react-redux'
 import { store } from './app/store'
 import App from './App'
 
-test('renders learn react link', () => {
+test.skip('prompts to Sign in with your Solid Identity', () => {
   const { getByText } = render(
     <Provider store={store}>
       <App />
     </Provider>,
   )
 
-  expect(getByText(/learn/i)).toBeInTheDocument()
+  // todo wait for async rendering of "Sign in with your Solid Identity"
+  expect(getByText(/initializing/i)).toBeInTheDocument()
 })


### PR DESCRIPTION
`yarn run test` was failing. Pointed out by Jos (from NLnet).

The test was just a stub to set up testing for the project. To be done... BDD so that functionalities emerge from requirements, executable specification, etc.

love and peace :)